### PR TITLE
Implement HTTP middleware and logging functionality

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -5,14 +5,16 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/codeandlearn1991/newsapi/internal/logger"
 	"github.com/codeandlearn1991/newsapi/internal/router"
 )
 
 func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}))
-	logger.Info("server starting on port 8080")
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}))
 	r := router.New()
-	if err := http.ListenAndServe(":8080", r); err != nil {
-		logger.Error("failed to start server", "error", err)
+	wrappedRouter := logger.AddLoggerMid(log, logger.LoggerMid(r))
+	log.Info("server starting on port 8080")
+	if err := http.ListenAndServe(":8080", wrappedRouter); err != nil {
+		log.Error("failed to start server", "error", err)
 	}
 }


### PR DESCRIPTION
## What this PR does
- Adds HTTP middleware for automatic request logging
- Implements context-aware logger injection
- Updates server to use middleware chain for all requests

## Changes made
- `internal/logger/log.go`: Added `LoggerMid` and `AddLoggerMid` functions
- `cmd/api-server/main.go`: Updated to use middleware chain
- Switched to text logging for better development experience

## Testing
- [x] Server starts successfully
- [x] All endpoints log requests with method and path
- [x] Middleware chain works correctly

## How to test
1. Start server: `go run cmd/api-server/main.go`
2. Make requests: `curl http://localhost:8080/news`
3. Verify logs show HTTP method and path