### PR TITLE
adding news model and validation

### DIFF
--- a/internal/handler/model.go
+++ b/internal/handler/model.go
@@ -1,0 +1,40 @@
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+type NewsPostReqBody struct {
+	Author    string   `json:"author"`
+	Title     string   `json:"title"`
+	Summary   string   `json:"summary"`
+	CreatedAt string   `json:"created_at"`
+	Content   string   `json:"content"`
+	Source    string   `json:"source"`
+	Tags      []string `json:"tags"`
+}
+
+func (n NewsPostReqBody) Validate() (errs error) {
+	if n.Author == "" {
+		errs = errors.Join(errs, fmt.Errorf("author is empty: %s", n.Author))
+	}
+	if n.Title == "" {
+		errs = errors.Join(errs, fmt.Errorf("title is empty: %s", n.Title))
+	}
+	if n.Summary == "" {
+		errs = errors.Join(errs, fmt.Errorf("summary is empty: %s", n.Summary))
+	}
+	if _, err := time.Parse(time.RFC3339, n.CreatedAt); err != nil {
+		errs = errors.Join(errs, err)
+	}
+	if _, err := url.Parse(n.Source); err != nil {
+		errs = errors.Join(errs, err)
+	}
+	if len(n.Tags) == 0 {
+		errs = errors.Join(errs, fmt.Errorf("tags is empty: %v", n.Tags))
+	}
+	return errs
+}

--- a/internal/handler/model_test.go
+++ b/internal/handler/model_test.go
@@ -1,0 +1,92 @@
+package handler_test
+
+import (
+	"testing"
+
+	"github.com/codeandlearn1991/newsapi/internal/handler"
+)
+
+func TestNewsPostReqBody_Validate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		req         handler.NewsPostReqBody
+		expectedErr bool
+	}{
+		{
+			name: "author empty",
+			req: handler.NewsPostReqBody{},
+			expectedErr: true,
+		},
+		{
+			name: "title empty",
+			req: handler.NewsPostReqBody{
+				Author: "test-author",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "summary empty",
+			req: handler.NewsPostReqBody{
+				Author: "test-author",
+				Title: "test-title",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "created_at invalid",
+			req: handler.NewsPostReqBody{
+				Author: "test-author",
+				Title: "test-title",
+				Summary: "test-summary",
+				CreatedAt: "invalid",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "source invalid",
+			req: handler.NewsPostReqBody{
+				Author: "test-author",
+				Title: "test-title",
+				Summary: "test-summary",
+				CreatedAt: "2025-07-30T15:30:45Z",
+				Source: "invalid",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "tags empty",
+			req: handler.NewsPostReqBody{
+				Author: "test-author",
+				Title: "test-title",
+				Summary: "test-summary",
+				CreatedAt: "2025-07-30T15:30:45Z",
+				Source: "https://example.com",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "validate",
+			req: handler.NewsPostReqBody{
+				Author: "test-author",
+				Title: "test-title",
+				Summary: "test-summary",
+				CreatedAt: "2025-07-30T15:30:45Z",
+				Source: "https://example.com",
+				Tags: []string{"tag1", "tag2"},
+			},
+			expectedErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.req.Validate()
+
+			if tc.expectedErr && err == nil {
+				t.Fatalf("expected error but got nil")
+			} else if !tc.expectedErr && err != nil {
+				t.Fatalf("expected nil but got error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 🔍 Add Input Validation for News API

### What this PR does
Implements comprehensive input validation for the `NewsPostReqBody` struct to ensure data integrity and provide clear error messages for invalid requests.

### Changes made
- **Added `NewsPostReqBody` struct** in `internal/handler/model.go`
  - Defines JSON structure for news post creation requests
  - Includes fields: author, title, summary, created_at, content, source, tags
- **Implemented `Validate()` method** with validation rules:
  - ✅ Required fields: author, title, summary must not be empty
  - ✅ Date validation: `created_at` must be valid RFC3339 format
  - ✅ URL validation: `source` must be a valid URL
  - ✅ Tags validation: at least one tag required
- **Added comprehensive test suite** in `internal/handler/model_test.go`
  - Tests for valid input scenarios
  - Tests for each validation rule failure
  - Uses table-driven testing approach

### Validation Rules
| Field | Rule | Error Message |
|-------|------|---------------|
| `author` | Required, non-empty | "author is empty" |
| `title` | Required, non-empty | "title is empty" |
| `summary` | Required, non-empty | "summary is empty" |
| `created_at` | Valid RFC3339 timestamp | Parse error details |
| `source` | Valid URL format | Parse error details |
| `tags` | At least one tag | "tags is empty" |

### Example Usage
```go
req := NewsPostReqBody{
    Author:    "John Doe",
    Title:     "Breaking News",
    Summary:   "Important update",
    CreatedAt: "2025-07-30T15:30:45Z",
    Content:   "Full article content",
    Source:    "https://www.reuters.com/news",
    Tags:      []string{"news", "breaking"},
}

if err := req.Validate(); err != nil {
    // Handle validation errors
}